### PR TITLE
Source and target paths is now dynamics

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Create a `.localeapprc` file where all the paths and locale information for the 
 ```json
 {
   "target": "locales",
-  "source": "locales/src",
+  "source": "locales",
   "default": "en"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @rimit/localeapp
+# @rimiti/localeapp
 
 [![Build Status](https://travis-ci.org/rimiti/localeapp.svg?branch=master)](https://travis-ci.org/rimiti/localeapp)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Create a `.localeapprc` file where all the paths and locale information for the 
 }
 ```
 
+It will generate the bellow folder structure:
+
+```
+src
+│
+├── locales/
+│   ├── en.yml
+│   ├── fr.yml
+│   ├── pt.yml
+│   ├── es.yml
+│   └── index.js
+│
+```
+
 #### If you want to create dynamic paths
 
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ $ yarn global add @rimiti/localeapp
 
 To start using `localeapp` there is a minimal set up that needs to be taken care of first.
 
-Create a `.localeapprc` file where all the paths and locale information for the `localeapp` commands is specified. A normal usage set up file looks like this
+Create a `.localeapprc` file where all the paths and locale information for the `localeapp` commands is specified. A normal usage set up file looks like this:
+
+#### If you want to use simple path definition
 
 ```json
 {
@@ -50,6 +52,34 @@ Create a `.localeapprc` file where all the paths and locale information for the 
   "source": "locales/src",
   "default": "en"
 }
+```
+
+#### If you want to create dynamic paths
+
+```
+{
+  "target": "locales/{{locale}}",
+  "source": "locales/{{locale}}",
+  "default": "en"
+}
+```
+
+The `{{locale}}` (or `{{ locale }}`) variable is automatically replaced by the locale. This option can be really useful if you need to create paths with the bellow structure:
+
+```
+src
+│
+├── locales/
+│   ├── en/
+│   │   └── en.yml
+│   ├── fr/
+│   │   └── fr.yml
+│   ├── pt/
+│   │   └── pt.yml
+│   ├── es/
+│   │   └── es.yml
+│   └── index.js
+│
 ```
 
 Where `target` is the path to the folder where your compiled translation keys file will be written, `source` is the root of your folder structure and `default` is the default language of your locales. `target` is also where all the locale files will be written to when pulling from Localeapp. In this example all local translation keys are in English, and the generated file (in `/locales`) is `en.yml`. It is this file that is then synchronised with Localeapp. The default locale should match the one in your remote  Localeapp project.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rimiti/localeapp",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "LocaleApp manager",
   "main": "dist/index.js",
   "repository": "https://github.com/rimiti/localeapp.git",

--- a/src/actions.js
+++ b/src/actions.js
@@ -54,8 +54,6 @@ function writeConfig(fd, keys) {
   });
 }
 
-
-
 /**
  * @description Pull translations.
  * @param rootFolder

--- a/src/actions.js
+++ b/src/actions.js
@@ -104,12 +104,11 @@ export function push(rootFolder, targetPath, locale, pushDefault, raw=false) {
 
   try {
     const localeappKey = JSON.parse(fs.readFileSync(getConfigPath(), 'utf8'))[getProjectName()];
+    localeReplacer.map((item) => targetPath = targetPath.replace(item, locale));
     const filePath = `${targetPath}/${locale}.yml`;
     const data = fs.createReadStream(filePath);
     return localeappPush(localeappKey, data)
-      .then(() => {
-        console.log(`Successfully pushed ${locale}.yml to Localeapp`);
-      })
+      .then(() => console.log(`Successfully pushed ${locale}.yml to Localeapp`))
       .catch((err) => console.error(err));
   }
   catch (err) {

--- a/src/actions.js
+++ b/src/actions.js
@@ -7,7 +7,8 @@ import {
   ymlToJson,
   jsonToYml,
   toFolders,
-  fromFolders
+  fromFolders,
+  createFile,
 } from './utils';
 
 /**
@@ -72,7 +73,7 @@ export function pull(rootFolder, targetPath, locale, raw=false) {
       console.log(`Successfully pulled locales ${Object.keys(localesArray).join(', ')} from Localeapp`);
       Object.entries(localesArray).map((l) => {
         const ymlLocale = jsonToYml({ [l[0]]: l[1] });
-        fs.writeFileSync(`${targetPath}/${l[0]}.yml`, ymlLocale);
+        createFile(targetPath, l[0], ymlLocale);
       });
       if (raw) return {};
       const compiledLocale = fs.readFileSync(`${targetPath}/${locale}.yml`, 'utf8');
@@ -85,7 +86,6 @@ export function pull(rootFolder, targetPath, locale, raw=false) {
     console.error('No localeapp project key found! Please specify one with the init command');
   }
 }
-
 
 /**
  * @description Push translations.

--- a/src/actions.js
+++ b/src/actions.js
@@ -9,6 +9,7 @@ import {
   toFolders,
   fromFolders,
   createFile,
+  localeReplacer,
 } from './utils';
 
 /**
@@ -68,19 +69,21 @@ export function pull(rootFolder, targetPath, locale, raw=false) {
     const configPath = getConfigPath();
     const projectName = getProjectName();
     const localeappKey = JSON.parse(fs.readFileSync(configPath, 'utf8'))[projectName];
-    return localeappPull(localeappKey).then(({ response, body }) => {
-      const localesArray = ymlToJson(body);
-      console.log(`Successfully pulled locales ${Object.keys(localesArray).join(', ')} from Localeapp`);
-      Object.entries(localesArray).map((l) => {
-        const ymlLocale = jsonToYml({ [l[0]]: l[1] });
-        createFile(targetPath, l[0], ymlLocale);
-      });
-      if (raw) return {};
-      const compiledLocale = fs.readFileSync(`${targetPath}/${locale}.yml`, 'utf8');
-      const updatedFolders = toFolders(rootFolder, compiledLocale, locale);
-      console.log('Folders updated');
-      return updatedFolders;
-    }).catch((err) => console.error(err));
+    return localeappPull(localeappKey)
+      .then(({ response, body }) => {
+        const localesArray = ymlToJson(body);
+        console.log(`Successfully pulled locales ${Object.keys(localesArray).join(', ')} from Localeapp`);
+        Object.entries(localesArray).map((l) => {
+          const ymlLocale = jsonToYml({ [l[0]]: l[1] });
+          createFile(targetPath, l[0], ymlLocale);
+        });
+        if (raw) return {};
+        const compiledLocale = fs.readFileSync(`${targetPath}/${locale}.yml`, 'utf8');
+        const updatedFolders = toFolders(rootFolder, compiledLocale, locale);
+        console.log('Folders updated');
+        return updatedFolders;
+      })
+      .catch((err) => console.error(err));
   }
   catch (err) {
     console.error('No localeapp project key found! Please specify one with the init command');

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -32,3 +32,18 @@ export function getProjectName() {
   }
   return name;
 }
+
+/**
+ * @description Create folder and file.
+ * @param path
+ * @param locale
+ * @param content
+ */
+export function createFile(path, locale, content) {
+  let pathTmp = path;
+  ['{{locale}}', '{{ locale }}'].map((item) => pathTmp = pathTmp.replace(item, locale));
+  if (!fs.existsSync(pathTmp)) {
+    fs.mkdirSync(pathTmp);
+  }
+  fs.writeFileSync(`${pathTmp}/${locale}.yml`, content);
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,8 @@ export * from './convert';
 export fromFolders from './from-folders';
 export toFolders from './to-folders';
 
+export const localeReplacer = ['{{locale}}', '{{ locale }}'];
+
 /**
  * @description Returns config path.
  * @param create
@@ -41,7 +43,7 @@ export function getProjectName() {
  */
 export function createFile(path, locale, content) {
   let pathTmp = path;
-  ['{{locale}}', '{{ locale }}'].map((item) => pathTmp = pathTmp.replace(item, locale));
+  localeReplacer.map((item) => pathTmp = pathTmp.replace(item, locale));
   if (!fs.existsSync(pathTmp)) {
     fs.mkdirSync(pathTmp);
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,7 +12,7 @@ export toFolders from './to-folders';
  */
 export function getConfigPath(create=false) {
   const home = require('user-home');
-  const directory = `${home}/.louki`;
+  const directory = `${home}/.localeapp`;
   if (!fs.existsSync(directory) && create) {
     fs.mkdirSync(directory);
   }


### PR DESCRIPTION
Hello,

It's now possible to dynamically customize your paths like that:

```
{
  "target": "locales/{{locale}}",
  "source": "locales/{{locale}}",
  "default": "en"
}
```

Folder structure generated:

```
src
│
├── locales/
│   ├── en/
│   │   └── en.yml
│   ├── fr/
│   │   └── fr.yml
│   ├── pt/
│   │   └── pt.yml
│   ├── es/
│   │   └── es.yml
│   └── index.js
│
```

Regards, 